### PR TITLE
Update install - reload nginx after adding nginx conf file

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -40,14 +40,14 @@ chmod +x -R "$install_dir/conduit"
 #=================================================
 ynh_script_progression --message="Adding system configurations related to $app..." --weight=1
 
-# Create a dedicated NGINX config using the conf/nginx.conf template
-ynh_add_nginx_config
-
 # Create .well-known redirection for access by federation
 if yunohost --output-as plain domain list | grep -q "^$server_name$"
 then
     ynh_add_config --template="server_name.conf" --destination="/etc/nginx/conf.d/${server_name}.d/${app}_server_name.conf"
 fi
+
+# Create a dedicated NGINX config using the conf/nginx.conf template
+ynh_add_nginx_config
 
 # Create a dedicated systemd config
 ynh_add_systemd_config


### PR DESCRIPTION
This way, nginx is reloaded after adding the nginx conf, not before and it would make federation working right away after install, no need for the installer to restart nginx after install.

## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
