### PR TITLE
update to release v0.8.0 url and sha256

### DIFF
--- a/doc/Admin.md
+++ b/doc/Admin.md
@@ -1,14 +1,20 @@
+### Login to Conduit
+
+[Integration into the YunoHost user database is not ready, yet.](https://github.com/YunoHost-Apps/conduit_ynh/issues/12) You need to **enable registration** in the apps configuration tab and then use a client to register an account. Afterwards you can disable registration again if you do not want allow anybody to register.
+
+Using the newly created account you should be able to login.
+
 ###  Coturn configuration
 
-To be able to take advantage of audio and video call functionalities, a coturn server is often required. It is possible to [install a coturn server in YunoHost (https://github.com/YunoHost-Apps/coturn-ynh/blob/master/README-en.md).
-It is then necessary to fill in the information provided by the coturn server in the file 'conduit.toml' such as:
+To be able to take advantage of audio and video call functionalities, a Coturn server is often required. It is possible to [install a Coturn server in YunoHost (https://github.com/YunoHost-Apps/coturn-ynh/blob/master/README-en.md).
+It is then necessary to fill in the information provided by the Coturn server in the file 'conduit.toml' such as:
 
 ```
 turn_uris = ["turns:your.turn.url:5349?transport=udp", "turns:your.turn.url:5349?transport=tcp"]
 turn_username = "<YOUR_USERNAME>"
 turn_password = "<YOUR_PASSWORD>"
 ```
-If your coturn (not Yunohost's one) don't use TLS, you might need to change a little bit like :
+If your Coturn (not YunoHost's one) does not use TLS, you might need to change a little bit like:
 ```
 turn_uris = ["turn:your.turn.url:5349?transport=udp", "turn:your.turn.url:5349?transport=tcp"]
 ``

--- a/manifest.toml
+++ b/manifest.toml
@@ -62,11 +62,11 @@ ram.runtime = "50M"
         in_subdir = false
         extract = false
         rename = "conduit"
-        amd64.url = "https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/x86_64-unknown-linux-musl?job=artifacts"
-        amd64.sha256 = "c5c21df55ec6159626cc158b1eae051c2572da8eb55a1e39a68c7fd38a11d7d3"
+        amd64.url = "https://gitlab.com/famedly/conduit/-/jobs/7085149318/artifacts/raw/x86_64-unknown-linux-musl?inline=false"
+        amd64.sha256 = "ae67b0fa1b74571de0363cb1a0c47930e615c340290215cbbbff6f8a60bbca0d"
 
-        arm64.url = "https://gitlab.com/api/v4/projects/famedly%2Fconduit/jobs/artifacts/next/raw/aarch64-unknown-linux-musl?job=artifacts"
-        arm64.sha256 = "61502ecb0ebd76e2b9648b523370299cec54f0dd38334e439267d36e7b8ee54b"
+        arm64.url = "https://gitlab.com/famedly/conduit/-/jobs/7085149318/artifacts/raw/aarch64-unknown-linux-musl"
+        arm64.sha256 = "3402d0d54a1dd3401aa7fe84538089f385d4b752ad5d6d32523de35e22f92a07"
 
 [resources.system_user]
 


### PR DESCRIPTION
## Problem

- link and sha256 are not up-to-date
Issue #40 

## Solution

- replace link of next branch artefacts, by link of artefacts of release v0.8.0 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
