### PR TITLE
Upgrade to 0.10.10~ynh1 & add dummy resource for autoupdater

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Simple, fast and reliable chat server powered by Matrix
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://conduit.rs/)
-[![Version: 0.10.8~ynh1](https://img.shields.io/badge/Version-0.10.8~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/conduit/)
+[![Version: 0.10.10~ynh1](https://img.shields.io/badge/Version-0.10.10~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/conduit/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/conduit"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Conduit"
 description.en = "Simple, fast and reliable chat server powered by Matrix"
 description.fr = "Serveur de chat simple, rapide et fiable alimenté par Matrix"
 
-version = "0.10.8~ynh1"
+version = "0.10.10~ynh1"
 
 maintainers = []
 
@@ -62,10 +62,10 @@ ram.runtime = "50M"
         in_subdir = false
         extract = false
         rename = "conduit"
-        amd64.url = "https://gitlab.com/famedly/conduit/-/jobs/10982682116/artifacts/raw/x86_64-unknown-linux-musl?inline=false"
-        amd64.sha256 = "8a158f5c38156ab08b37c153231c03dcd20e62fb4bf121d646ea134f7be27c14"
-        arm64.url = "https://gitlab.com/famedly/conduit/-/jobs/10982682116/artifacts/raw/aarch64-unknown-linux-musl?inline=false"
-        arm64.sha256 = "936e2e94adfdfe19c2a8f87758af95ae4e24599d276c0704a51ee6b3d86cba1e"
+        amd64.url = "https://gitlab.com/famedly/conduit/-/jobs/12522761291/artifacts/raw/x86_64-unknown-linux-musl"
+        amd64.sha256 = "5a5d55c85156a3825705de65f2d6217738d456bdc5f90753af3365bd46d3c31a"
+        arm64.url = "https://gitlab.com/famedly/conduit/-/jobs/12522761291/artifacts/raw/aarch64-unknown-linux-musl"
+        arm64.sha256 = "fcd8e9a8918c5b2e21d2bf3964324fd800dbf30adbdeba1f8ed406d4980904c7"
 
 [resources.system_user]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/YunoHost/apps/master/schemas/manifest.v2.schema.json
+
 packaging_format = 2
 
 id = "conduit"
@@ -59,6 +61,12 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
+        prefetch = false
+        url = "https://gitlab.com/famedly/conduit/-/archive/v0.10.10/conduit-v0.10.10.tar.gz"
+        sha256 = "nonethisisadummyanruisetanursietanurisetanursietaunierstauinress"
+        autoupdate.strategy = "latest_gitlab_release"
+
+        [resources.sources.binaries]
         in_subdir = false
         extract = false
         rename = "conduit"

--- a/scripts/install
+++ b/scripts/install
@@ -16,7 +16,7 @@ ynh_app_setting_set --key=federation --value=$federation
 #=================================================
 ynh_script_progression "Setting up source files..."
 
-ynh_setup_source --dest_dir="$install_dir"
+ynh_setup_source --dest_dir="$install_dir" --source_id=binaries
 
 chown -R $app:root "$install_dir"
 chmod +x "$install_dir/conduit"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -15,7 +15,7 @@ ynh_systemctl --service=$app --action="stop" --log_path="systemd"
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir" --keep="conduit.toml"
+ynh_setup_source --dest_dir="$install_dir" --source_id=binaries --keep="conduit.toml"
 
 chown -R $app:root "$install_dir"
 chmod +x "$install_dir/conduit"


### PR DESCRIPTION
- Fix critical CVE-2025-68667
  - https://github.com/continuwuity/continuwuity/security/advisories/GHSA-22fw-4jq7-g8r8
  - https://nvd.nist.gov/vuln/detail/CVE-2025-68667
 - Add dummy resource so that autoupdater notifies when there is a new version available (though binaries' URLs will still have to be updated manually)