### PR TITLE
Upgrade to 0.10.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Simple, fast and reliable chat server powered by Matrix
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://conduit.rs/)
-[![Version: 0.10.10~ynh1](https://img.shields.io/badge/Version-0.10.10~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/conduit/)
+[![Version: 0.10.11~ynh1](https://img.shields.io/badge/Version-0.10.11~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/conduit/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/conduit"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -70,10 +70,10 @@ ram.runtime = "50M"
         in_subdir = false
         extract = false
         rename = "conduit"
-        amd64.url = "https://gitlab.com/famedly/conduit/-/jobs/12522761291/artifacts/raw/x86_64-unknown-linux-musl"
-        amd64.sha256 = "5a5d55c85156a3825705de65f2d6217738d456bdc5f90753af3365bd46d3c31a"
-        arm64.url = "https://gitlab.com/famedly/conduit/-/jobs/12522761291/artifacts/raw/aarch64-unknown-linux-musl"
-        arm64.sha256 = "fcd8e9a8918c5b2e21d2bf3964324fd800dbf30adbdeba1f8ed406d4980904c7"
+        amd64.url = "https://gitlab.com/famedly/conduit/-/jobs/12572491120/artifacts/raw/x86_64-unknown-linux-musl"
+        amd64.sha256 = "589867ce1a0fb07c104feae8f0d5e15aee8328983bdc4ebc488d46a86ea5f63b"
+        arm64.url = "https://gitlab.com/famedly/conduit/-/jobs/12572491120/artifacts/raw/aarch64-unknown-linux-musl"
+        arm64.sha256 = "bcaa83e9447831890f2032acd0081d14bded08b68136ea4430e17819b44b3a8d"
 
 [resources.system_user]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Conduit"
 description.en = "Simple, fast and reliable chat server powered by Matrix"
 description.fr = "Serveur de chat simple, rapide et fiable alimenté par Matrix"
 
-version = "0.10.10~ynh1"
+version = "0.10.11~ynh1"
 
 maintainers = []
 
@@ -62,8 +62,8 @@ ram.runtime = "50M"
 
         [resources.sources.main]
         prefetch = false
-        url = "https://gitlab.com/famedly/conduit/-/archive/v0.10.10/conduit-v0.10.10.tar.gz"
-        sha256 = "nonethisisadummyanruisetanursietanurisetanursietaunierstauinress"
+        url = "https://gitlab.com/famedly/conduit/-/archive/v0.10.11/conduit-v0.10.11.tar.bz2"
+        sha256 = "d75ad0abf380973f4c7de1e6ca279d0b55764a8265fd28029bafdd3504ceec75"
         autoupdate.strategy = "latest_gitlab_release"
 
         [resources.sources.binaries]


### PR DESCRIPTION
> Fixes another critical vulnerability, similar to the previous one, again allowing for remote servers to make Conduit sign arbitrary events, but unlike the last vulnerability, it requires user interaction.

https://gitlab.com/famedly/conduit/-/releases/v0.10.11